### PR TITLE
Fix build broken by serde::__private removal in serde 1.0.228

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,8 @@ version = 4
 name = "activity-vocabulary"
 version = "0.0.5"
 dependencies = [
- "activity-vocabulary-core 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "activity-vocabulary-derive 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "activity-vocabulary-core",
+ "activity-vocabulary-derive",
  "anyhow",
  "diff",
  "serde",
@@ -31,38 +31,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "activity-vocabulary-core"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4690b654624e06932d73da0a4409a147453d0670a3c05bed52f2c9ed292b1825"
-dependencies = [
- "chrono",
- "nom",
- "serde",
- "serde-value",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "activity-vocabulary-derive"
 version = "0.0.5"
-dependencies = [
- "anyhow",
- "maplit",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "serde_yaml",
- "syn",
-]
-
-[[package]]
-name = "activity-vocabulary-derive"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4031645fa0c35cb7f6d268df4ffbb38b463f4a56df66db1f347f73d69e8f4e"
 dependencies = [
  "anyhow",
  "maplit",
@@ -82,15 +52,15 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
 ]
@@ -114,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "form_urlencoded"
@@ -129,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "icu_collections"
@@ -238,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -248,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "litemap"
@@ -266,9 +236,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -288,18 +258,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
@@ -339,16 +309,17 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -363,10 +334,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.188"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -375,20 +355,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",
@@ -443,18 +425,18 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444d8748011b93cb168770e8092458cb0f8854f931ff82fdf6ddfbd72a9c933e"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -463,15 +445,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -574,3 +556,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/activity-vocabulary-core/src/lib.rs
+++ b/activity-vocabulary-core/src/lib.rs
@@ -79,14 +79,19 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Property<T> {
     where
         D: serde::Deserializer<'de>,
     {
-        let content = serde::__private::de::Content::deserialize(deserializer)?;
-        let deserializer = serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
-        match Vec::<T>::deserialize(deserializer) {
+        let value = serde_value::Value::deserialize(deserializer)?;
+        match Vec::<T>::deserialize(serde_value::ValueDeserializer::<D::Error>::new(
+            value.clone(),
+        )) {
             Ok(inner) => Ok(Self(inner)),
-            Err(seq_err) => match Option::<T>::deserialize(deserializer) {
-                Ok(inner) => Ok(Self(inner.into_iter().collect())),
-                Err(opt_err) => Err(serde::de::Error::custom(format!("{seq_err} & {opt_err}"))),
-            },
+            Err(seq_err) => {
+                match Option::<T>::deserialize(serde_value::ValueDeserializer::<D::Error>::new(
+                    value,
+                )) {
+                    Ok(inner) => Ok(Self(inner.into_iter().collect())),
+                    Err(opt_err) => Err(serde::de::Error::custom(format!("{seq_err} & {opt_err}"))),
+                }
+            }
         }
     }
 }
@@ -108,11 +113,12 @@ impl<'de, L: Deserialize<'de>, R: Deserialize<'de>> Deserialize<'de> for Or<L, R
     where
         D: serde::Deserializer<'de>,
     {
-        let content = serde::__private::de::Content::deserialize(deserializer)?;
-        let deserializer = serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
-        match L::deserialize(deserializer) {
+        let value = serde_value::Value::deserialize(deserializer)?;
+        match L::deserialize(serde_value::ValueDeserializer::<D::Error>::new(
+            value.clone(),
+        )) {
             Ok(left) => Ok(Self::Prim(left)),
-            Err(left_err) => R::deserialize(deserializer)
+            Err(left_err) => R::deserialize(serde_value::ValueDeserializer::<D::Error>::new(value))
                 .map_err(|right_err| {
                     serde::de::Error::custom(format!("{left_err} and {right_err}"))
                 })

--- a/activity-vocabulary/Cargo.toml
+++ b/activity-vocabulary/Cargo.toml
@@ -11,11 +11,11 @@ description = "Type definitions of Activity Vocabulary 2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.htmlname = "activity-vocabulary"
 
 [build-dependencies]
-activity-vocabulary-derive = "0.0.5"
+activity-vocabulary-derive = { version = "0.0.5", path = "../activity-vocabulary-derive" }
 serde_yaml = "0.9"
 
 [dependencies]
-activity-vocabulary-core = "0.0.5"
+activity-vocabulary-core = { version = "0.0.5", path = "../activity-vocabulary-core" }
 serde = { workspace = true, features = ["derive"] }
 serde-value.workspace = true
 typed-builder = "0.18"


### PR DESCRIPTION
serde 1.0.228 moved the internal Content / ContentRefDeserializer types out of serde::__private into serde_core, so the buffered-deserialize trick in Property and Or no longer compiled. Rewrite both Deserialize impls to use serde_value::Value, matching the existing Remotable impl and removing the dependency on serde internals.

Also point the main crate at the workspace path versions of activity-vocabulary-core and -derive so local fixes are actually built.